### PR TITLE
feat: add mobile bottom navigation bar

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -387,6 +387,71 @@ h1 .highlight {
   border-bottom-color: var(--accent);
 }
 
+/* ========== MOBILE BOTTOM NAV ========== */
+.mobile-nav {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .nav {
+    display: none;
+  }
+
+  .mobile-nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    background: var(--bg);
+    border-top: 1px solid var(--border);
+    padding: 0.4rem 0;
+    padding-bottom: calc(0.4rem + env(safe-area-inset-bottom, 0px));
+    transition: background 0.3s;
+  }
+
+  [data-theme="dark"] .mobile-nav {
+    background: rgba(13,17,23,0.95);
+    backdrop-filter: blur(12px);
+  }
+
+  .mobile-nav a {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.2rem;
+    text-decoration: none;
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    padding: 0.3rem 0.5rem;
+    border-radius: 6px;
+    transition: color 0.15s;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .mobile-nav a svg {
+    transition: color 0.15s;
+  }
+
+  .mobile-nav a.active {
+    color: var(--accent);
+  }
+
+  .mobile-nav a.active svg {
+    color: var(--accent);
+  }
+
+  body {
+    padding-bottom: calc(60px + env(safe-area-inset-bottom, 0px));
+  }
+}
+
 /* ========== SECTIONS ========== */
 section {
   max-width: 1400px;
@@ -1152,19 +1217,6 @@ footer a:hover {
       linear-gradient(to left, var(--surface), var(--surface)) right / 20px 100% no-repeat local,
       radial-gradient(farthest-side at 0 50%, rgba(0,0,0,.12), transparent) left / 12px 100% no-repeat scroll,
       radial-gradient(farthest-side at 100% 50%, rgba(0,0,0,.12), transparent) right / 12px 100% no-repeat scroll;
-  }
-
-  /* Scroll indicator gradient on nav */
-  .nav::after {
-    content: '';
-    position: absolute;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    width: 30px;
-    background: linear-gradient(to right, transparent, var(--bg));
-    pointer-events: none;
-    z-index: 101;
   }
 
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -514,9 +514,9 @@ document.addEventListener('alpine:init', () => {
   }));
 
   // ==========================
-  // ALPINE DATA: NAV SCROLLER
+  // ALPINE STORE: NAV (shared scroll spy state)
   // ==========================
-  Alpine.data('navScroller', () => ({
+  Alpine.store('nav', {
     currentSection: '',
 
     init() {
@@ -537,6 +537,6 @@ document.addEventListener('alpine:init', () => {
     isActive(href) {
       return href === '#' + this.currentSection;
     }
-  }));
+  });
 
 });

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,11 +1,34 @@
-<nav class="nav" id="nav" x-data="navScroller">
+<nav class="nav" id="nav">
   <div class="nav-inner">
-    <a href="#overview" :class="{ 'active': isActive('#overview') }">overview</a>
-    <a href="#metrics" :class="{ 'active': isActive('#metrics') }">metrics</a>
-    <a href="#headless-hybrid" :class="{ 'active': isActive('#headless-hybrid') }">headless</a>
-    <a href="#comparison" :class="{ 'active': isActive('#comparison') }">comparison</a>
-    <a href="#wizard" :class="{ 'active': isActive('#wizard') }">qfd_matrix</a>
-    <a href="#executive" :class="{ 'active': isActive('#executive') }">summary</a>
-    <a href="#confidence" :class="{ 'active': isActive('#confidence') }">methodology</a>
+    <a href="#overview" :class="{ 'active': $store.nav.isActive('#overview') }">overview</a>
+    <a href="#metrics" :class="{ 'active': $store.nav.isActive('#metrics') }">metrics</a>
+    <a href="#headless-hybrid" :class="{ 'active': $store.nav.isActive('#headless-hybrid') }">headless</a>
+    <a href="#comparison" :class="{ 'active': $store.nav.isActive('#comparison') }">comparison</a>
+    <a href="#wizard" :class="{ 'active': $store.nav.isActive('#wizard') }">qfd_matrix</a>
+    <a href="#executive" :class="{ 'active': $store.nav.isActive('#executive') }">summary</a>
+    <a href="#confidence" :class="{ 'active': $store.nav.isActive('#confidence') }">methodology</a>
   </div>
+</nav>
+
+<nav class="mobile-nav" id="mobile-nav">
+  <a href="#overview" :class="{ 'active': $store.nav.isActive('#overview') }">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+    <span>Overview</span>
+  </a>
+  <a href="#metrics" :class="{ 'active': $store.nav.isActive('#metrics') }">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+    <span>Metrics</span>
+  </a>
+  <a href="#comparison" :class="{ 'active': $store.nav.isActive('#comparison') }">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+    <span>Compare</span>
+  </a>
+  <a href="#wizard" :class="{ 'active': $store.nav.isActive('#wizard') }">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><line x1="4" y1="10" x2="20" y2="10"/><line x1="10" y1="4" x2="10" y2="20"/></svg>
+    <span>QFD</span>
+  </a>
+  <a href="#executive" :class="{ 'active': $store.nav.isActive('#executive') }">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+    <span>Summary</span>
+  </a>
 </nav>


### PR DESCRIPTION
## Summary

- Added a fixed bottom navigation bar for mobile devices (<=768px) with 5 tabs: Overview, Metrics, Compare, QFD, Summary — each with inline SVG icons and labels
- Refactored `navScroller` from Alpine.data to Alpine.store so both the desktop top nav and mobile bottom nav share scroll spy state from a single scroll listener
- Desktop top nav is hidden on mobile; mobile bottom nav is hidden on desktop
- Dark mode support with backdrop blur, safe-area-inset-bottom for iPhone home indicator, and smooth color transitions on active state

Closes #3

## Test plan

- [x] Mobile viewport (375x812): bottom nav visible, top nav hidden
- [x] Desktop viewport (1440x900): top nav visible, bottom nav hidden
- [x] Scroll spy: active section correctly highlighted in bottom nav
- [x] Tap navigation: tapping each tab scrolls to the correct section
- [x] Dark mode: bottom nav has proper dark background with backdrop blur
- [x] Light mode: clean white background with subtle border
- [x] Console: zero JS errors or warnings
- [x] Desktop nav: still works correctly with shared Alpine store

Made with [Cursor](https://cursor.com)